### PR TITLE
fix: 現在地の地区予報区が取得できない問題を修正

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -32,7 +32,7 @@
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 
-    <base href="https://webapp.ydits.net/">
+    <!-- <base href="https://webapp.ydits.net/"> -->
 
     <link rel="shortcut icon" type="image/x-icon" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <link rel="apple-touch-icon-precomposed" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">

--- a/src/pages/scripts/ydits-web/services/modules/geolocation.mjs
+++ b/src/pages/scripts/ydits-web/services/modules/geolocation.mjs
@@ -93,7 +93,14 @@ export class GeoLocation extends Service {
             + "&zoom=12"
             + "&addressdetails=1";
 
-        await fetch(urlCity)
+        await fetch(
+            urlCity,
+            {
+                headers: {
+                    "Accept-Language": "ja-JP"
+                }
+            }
+        )
             .then((response) => response.json())
             .then(async (data) => {
                 if (data === null || data.address === undefined) { return }
@@ -144,7 +151,6 @@ export class GeoLocation extends Service {
                     if (["北区", "南区", "西区"].includes(this.city)) {
                         this.province = data.address.province;
                         this.area = this.app.services.eew.removePref(this.province) + this.city;
-                        console.debug(this.area);
                     }
                 } else if (data.address.town) {
                     // 町村


### PR DESCRIPTION
## Changes

### Modify

- [x] [/src/pages/scripts/ydits-web/services/modules/geolocation.mjs] で、Nominatim APIのリクエストヘッダーに `"Accept-Language": "ja-JP"` を追加する
指定しない場合はブラウザの言語を選択されるため、正しく現在地の市区町村を取得できない。
