### PR TITLE
fix(Wolfx): EEW警報の効果音が連続して再生される問題を修正

### DIFF
--- a/src/pages/scripts/ydits-web/services/wolfx/wolfx.js
+++ b/src/pages/scripts/ydits-web/services/wolfx/wolfx.js
@@ -287,7 +287,7 @@ export class Wolfx extends Service {
      * @returns {void}
      */
     sound() {
-        if (this.jmaEewData.isCancel) {
+        if (this.jmaEewData.isCancel || this.jmaEewData.eventId !== this.lastEventId) {
             if (this.app.services.settings.sound.eewCancel == true) {
                 this.app.services.sounds.eewVoiceCancel.play();
             }
@@ -298,7 +298,7 @@ export class Wolfx extends Service {
 
         if (!this.app.services.settings.sound.eewAny) { return }
 
-        if (this.jmaEewData.isWarning) {
+        if (this.jmaEewData.isWarning && this.jmaEewData.eventId !== this.lastEventId) {
             this.app.services.sounds.eew.play();
             this.app.services.sounds.eewWarnVoice.play();
         }


### PR DESCRIPTION
## Changes

### Fix

- [x] #94 
  The previous implementation of the EEW sound logic caused the warning sound to be played on every update for the same event as long as `isWarning` was true. This resulted in multiple, redundant sound notifications for a single earthquake event.
  This commit introduces a check against the `eventId` to ensure that sounds are only triggered once for each new event.

  - The EEW warning sound will now only play if `isWarning` is true and the `eventId` is new.
  - The EEW cancellation sound will now play either when a cancellation report is received or when a new event supersedes the previous one.

  This prevents repetitive audio alerts and provides a more user-friendly notification experience.