### PR TITLE
feat(Map): EEWのS波/P波到達予想円のレンダリングフレームレートを可変に対応

### DIFF
--- a/src/pages/scripts/ydits-web/services/map/map.js
+++ b/src/pages/scripts/ydits-web/services/map/map.js
@@ -543,7 +543,7 @@ export class Map extends Service {
      * @param {*} dateNow
      * @returns {void}
      */
-    update(dateNow) {
+    update(dateNow, fps) {
         try {
             if (!this.app.services.api.yahooKmoni.isEew) {
                 if (!this.isDisplayHrpns) this.showHrpns();
@@ -566,7 +566,7 @@ export class Map extends Service {
                     this.app.services.eew.reports[id].pRadius = this.app.services.eew.reports[id].psWave.pRadius * 1000;
 
                     if (this.app.services.eew.reports[id].sRadius != this.app.services.eew.reports[id].lastSWave) {
-                        this.app.services.eew.reports[id].sWaveInterval = (this.app.services.eew.reports[id].sRadius - this.app.services.eew.reports[id].lastSWave) / 60;
+                        this.app.services.eew.reports[id].sWaveInterval = (this.app.services.eew.reports[id].sRadius - this.app.services.eew.reports[id].lastSWave) / fps;
                         this.app.services.eew.reports[id].lastSWave = this.app.services.eew.reports[id].sRadius;
                         this.app.services.eew.reports[id].sWavePut = this.app.services.eew.reports[id].sRadius;
                     } else if (this.app.services.eew.reports[id].sRadius == this.app.services.eew.reports[id].lastSWave) {
@@ -574,7 +574,7 @@ export class Map extends Service {
                     }
 
                     if (this.app.services.eew.reports[id].pRadius != this.app.services.eew.reports[id].lastPWave) {
-                        this.app.services.eew.reports[id].pWaveInterval = (this.app.services.eew.reports[id].pRadius - this.app.services.eew.reports[id].lastPWave) / 60;
+                        this.app.services.eew.reports[id].pWaveInterval = (this.app.services.eew.reports[id].pRadius - this.app.services.eew.reports[id].lastPWave) / fps;
                         this.app.services.eew.reports[id].lastPWave = this.app.services.eew.reports[id].pRadius;
                         this.app.services.eew.reports[id].pWavePut = this.app.services.eew.reports[id].pRadius;
                         this.#loopCount = dateNow;

--- a/src/pages/scripts/ydits-web/ydits-web.js
+++ b/src/pages/scripts/ydits-web/ydits-web.js
@@ -420,7 +420,7 @@ export class YditsWeb extends FirebaseApp {
         const timeNowMs = performance.now();
         this.#calcFps(timeNowMs);
         this.#displayFps(timeNowMs);
-        this.services.map.update(timeNow);
+        this.services.map.update(timeNow, this.#fps);
         requestAnimationFrame(() => this.#mainloop());
     }
 


### PR DESCRIPTION
## Changes

### Feature

- #93 
  feat: Improve map animation smoothness with FPS-dependent wave calculations.
  The map's wave propagation animations (s-wave and p-wave) were previously calculated using a fixed divisor of 60, which could lead to inconsistent animation speeds across different frame rates.
  This commit modifies the `map.update` method to accept the current frames per second (FPS) as a parameter. The wave interval calculations now utilize this FPS value, ensuring that the animation speed remains consistent and smooth regardless of the client's rendering performance.
  Specifically:
    - `map.update` now takes an additional `fps` argument.
    - `sWaveInterval` and `pWaveInterval` calculations in `map.js` now divide by  `fps` instead of a fixed `60`.
    - The `ydits-web.js` main loop now passes `this.#fps` to `map.update`.