### PR TITLE
feat: ライセンス表記に "render.js" を追加

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -915,6 +915,53 @@
 
                         <li class="licenses__item">
                             <h3 class="licenses__name">
+                                <a href="https://github.com/yone1130/render-js" target="_blank">
+                                    render.js
+
+                                    <span class="material-symbols-outlined open-in-new">
+                                        open_in_new
+                                    </span>
+                                </a>
+                            </h3>
+
+                            <div class="licenses__resource">
+                                <p>
+                                    HTML DOM レンダリングライブラリ (CDN Module の利用)
+                                </p>
+                            </div>
+
+                            <div class="licenses__license">
+                                <p>
+                                    Licensed under the
+
+                                    <a target="_blank" href="https://github.com/yone1130/render-js/blob/main/LICENSE">
+                                        MIT License
+
+                                        <span class="material-symbols-outlined open-in-new">
+                                            open_in_new
+                                        </span>
+                                    </a>
+                                </p>
+                            </div>
+
+                            <div class="licenses__copyright">
+                                <p>
+                                    ©
+                                    <a target="_blank" href="https://www.yoneyo.com/">
+                                        よね/Yone
+
+                                        <span class="material-symbols-outlined open-in-new">
+                                            open_in_new
+                                        </span>
+                                    </a>
+                                </p>
+                            </div>
+                        </li>
+
+                        <hr class="enwfew">
+
+                        <li class="licenses__item">
+                            <h3 class="licenses__name">
                                 <a target="_blank" href="https://axios-http.com/">
                                     Axios
 


### PR DESCRIPTION
## Changes

### Feature

- #109 
  feat: Add render.js to license list
  Adds a new entry for the "render.js" library to the licenses section in the main index page.
  Key changes:
    - **License Entry**: Added "render.js" (HTML DOM rendering library) to the license list in `index.html`.
    - **Project Details**: Included official repository links, MIT license information, and copyright attribution for the library.