### PR TITLE
feat: MapTiler の CSS を削除

### DIFF
--- a/src/pages/eqhistory/index.html
+++ b/src/pages/eqhistory/index.html
@@ -64,7 +64,6 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-
     <script src="/scripts/common.js" type="module"></script>
     <script src="/scripts/main.js" type="module"></script>
 

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -59,9 +59,6 @@
 
     <!-- Styles -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maplibre-gl@^5.3.0/dist/maplibre-gl.css">
-    <link rel="stylesheet" href="https://cdn.maptiler.com/maptiler-geocoding-control/v2.1.4/style.css">
-    <link rel="stylesheet" href="https://cdn.maptiler.com/maptiler-sdk-js/v1.2.0/maptiler-sdk.css">
-
     <link rel="stylesheet" href="./styles/common.css">
     <link rel="stylesheet" href="./styles/ui.css">
     <link rel="stylesheet" href="./styles/app.css">


### PR DESCRIPTION
## Changes

### Feature

- #113 
  feat: Remove unused MapTiler CSS dependencies and clean up HTML
  Removes redundant MapTiler Geocoding and SDK CSS links from the main index page to streamline external dependencies. It also performs minor formatting cleanup in the earthquake history page.
  Key changes:
    - **Style Cleanup**: Removed unused MapTiler Geocoding Control and MapTiler SDK CSS imports from `index.html`.
    - **HTML Formatting**: Cleaned up redundant whitespace and ensured proper trailing newline in `eqhistory/index.html`.