### PR TITLE
feat: ライセンス表記の MapTiler の項目を変更

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1100,23 +1100,7 @@
 
                             <div class="licenses__resource">
                                 <p>
-                                    マップ画像、
-                                    <a href="https://docs.maptiler.com/sdk-js/" target="_blank">
-                                        MapTiler SDK JS
-
-                                        <span class="material-symbols-outlined open-in-new">
-                                            open_in_new
-                                        </span>
-                                    </a>
-                                    (CDN Module を利用)、
-                                    <a href="https://github.com/maptiler/leaflet-maptilersdk" target="_blank">
-                                        MapTiler SDK Leaflet Module
-
-                                        <span class="material-symbols-outlined open-in-new">
-                                            open_in_new
-                                        </span>
-                                    </a>
-                                    (CDN Module を利用) の提供
+                                    マップ画像の提供
                                 </p>
                             </div>
 


### PR DESCRIPTION
## Changes

### Feature

- #115 
  feat: Simplify MapTiler attribution in license window
  Streamlines the license and attribution section in the main landing page by removing specific mentions of MapTiler SDK modules.
  Key changes:
    - **Map Attribution**: Simplified the description of map services to a general "map image provider" credit.
    - **Dependency Cleanup**: Removed explicit links and mentions of MapTiler SDK JS and MapTiler SDK Leaflet Module from the UI.