### PR TITLE
refactor(ui): CSS で vw/vh を dynamic/small/large に置き換える

### DIFF
--- a/src/pages/help/sound-setting/styles/index.css
+++ b/src/pages/help/sound-setting/styles/index.css
@@ -27,17 +27,17 @@ main>.content>.content {
 }
 
 main>.content>.content>img {
-    width: 40vw;
+    width: 40dvw;
 }
 
 @media (max-width: 768px) {
     main {
-        width: calc(100% - 20vw);
-        padding-left: 10vw;
-        padding-right: 10vw;
+        width: calc(100% - 20dvw);
+        padding-left: 10dvw;
+        padding-right: 10dvw;
     }
 
     main>.content>.content>img {
-        width: 70vw;
+        width: 70dvw;
     }
 }

--- a/src/pages/help/styles/index.css
+++ b/src/pages/help/styles/index.css
@@ -16,9 +16,9 @@ html {
 }
 
 main {
-    width: calc(100% - 20vw);
-    padding: 5rem 10vw;
-    min-height: 100vh;
+    width: calc(100% - 20dvw);
+    padding: 5rem 10dvw;
+    min-height: 100dvh;
     height: auto;
 }
 
@@ -61,10 +61,10 @@ main {
 
 @media (max-width: 768px) {
     main {
-        width: calc(100% - 4vw);
+        width: calc(100% - 4dvw);
 
-        padding-left: 2vw;
-        padding-right: 2vw;
+        padding-left: 2dvw;
+        padding-right: 2dvw;
     }
 
     #links .link {

--- a/src/pages/styles/app.css
+++ b/src/pages/styles/app.css
@@ -293,7 +293,7 @@ main {
 
 #mapWrapper {
     position: relative;
-    width: calc(100vw - var(--control-width));
+    width: calc(100dvw - var(--control-width));
     height: 100%;
 }
 
@@ -427,7 +427,7 @@ main {
     width: 100%;
     height: 100%;
     top: 0;
-    left: 100vw;
+    left: 100dvw;
     border-radius: 0;
     z-index: 1;
     background-color: #202020e0;
@@ -506,7 +506,7 @@ main {
     position: fixed;
     top: 100svh;
     left: 0;
-    width: 100vw;
+    width: 100dvw;
     height: calc(100svh - 2rem);
     background-color: #101010c0;
     /* background-color: rgba(40, 40, 40, .75); */
@@ -645,7 +645,7 @@ main {
 
 #jmaDataFeed {
     top: calc(env(titlebar-area-height, 2rem) + 1rem);
-    left: 100vw;
+    left: 100dvw;
 }
 
 #jmaDataFeed.active {
@@ -655,7 +655,7 @@ main {
 
 #jmaDataFeedEqvol {
     top: calc(env(titlebar-area-height, 2rem) + 1rem);
-    left: 100vw;
+    left: 100dvw;
 }
 
 #jmaDataFeedEqvol.active {
@@ -665,7 +665,7 @@ main {
 
 #jmaDataFeedEqvolLong {
     top: calc(env(titlebar-area-height, 2rem) + 1rem);
-    left: 100vw;
+    left: 100dvw;
 }
 
 #jmaDataFeedEqvolLong.active {
@@ -690,7 +690,7 @@ main {
 
 #settings {
     top: calc(env(titlebar-area-height, 2rem) + 1rem);
-    left: 100vw;
+    left: 100dvw;
 }
 
 #settings.active {
@@ -776,7 +776,7 @@ main {
 
 .window.settings_list {
     top: calc(env(titlebar-area-height, 2rem) + 1rem);
-    left: 100vw;
+    left: 100dvw;
 }
 
 .window.settings_list.active {
@@ -885,7 +885,7 @@ main {
     position: absolute;
     right: 2rem;
     top: 2rem;
-    border-radius: 100vw;
+    border-radius: 100lvw;
     padding: 0 0.5rem;
     background-color: #e04040;
     opacity: 0.5;
@@ -908,7 +908,7 @@ main {
     position: absolute;
     bottom: 0;
     left: 0;
-    max-width: 100vw;
+    max-width: 100dvw;
     font-size: 0.8rem;
     z-index: 2;
     pointer-events: none;
@@ -941,12 +941,12 @@ main {
 
     #control {
         display: flex;
-        width: 100vw;
+        width: 100dvw;
         height: 14em;
     }
 
     #map {
-        width: 100vw;
+        width: 100dvw;
     }
 
     #mapWrapper {

--- a/src/pages/styles/common.css
+++ b/src/pages/styles/common.css
@@ -21,7 +21,7 @@
     --color-link: #33ffa0;
 
     /* header */
-    --header-width-default: 100vw;
+    --header-width-default: 100dvw;
     --header-height-default: 2rem;
     --header-width: env(titlebar-area-width, var(--header-width-default));
     --header-height: env(titlebar-area-height, var(--header-height-default));

--- a/src/pages/styles/ui.css
+++ b/src/pages/styles/ui.css
@@ -32,8 +32,8 @@
 
 .dialog {
     position: fixed;
-    top: calc(50vh - 14rem);
-    left: calc(50vw - 16rem);
+    top: calc(50dvh - 14rem);
+    left: calc(50dvw - 16rem);
     display: block;
 
     width: 32rem;
@@ -101,11 +101,11 @@
 
     @media (max-width: 769px) {
         position: fixed;
-        top: 8vh;
-        left: 8vw;
+        top: 8dvh;
+        left: 8dvw;
         margin: 0;
-        width: 84vw;
-        height: 84vh;
+        width: 84dvw;
+        height: 84dvh;
     }
 }
 
@@ -163,7 +163,7 @@
     margin-left: 2rem;
     border-radius: 1rem;
     box-shadow: 0 0 2px 2px #00000040;
-    max-width: calc(100vw - 4rem);
+    max-width: calc(100dvw - 4rem);
     overflow: auto;
     padding: 1rem 2rem;
     background-color: #404040ff;
@@ -192,7 +192,7 @@
     margin-right: 2rem;
     border-radius: 1rem;
     box-shadow: 0 0 2px 2px #00000040;
-    max-width: calc(100vw - 4rem);
+    max-width: calc(100dvw - 4rem);
     overflow: auto;
     padding: 1rem 2rem;
     background-color: #f04040ff;
@@ -259,8 +259,8 @@
 }
 
 #eewAreas {
-    width: calc(100% - 10vw);
-    padding: 2rem 5vw;
+    width: calc(100% - 10dvw);
+    padding: 2rem 5dvw;
     font-size: 1.3rem;
 
     &>.label {


### PR DESCRIPTION
## Changes

### Refactor

- #121 
  refactor(ui): Migrate viewport units to dynamic/static variants
  Replaces standard viewport units (vw, vh) with dynamic (dvw, dvh), small (svh), and large (lvw) viewport units across several CSS files. This update improves layout stability on mobile devices where browser UI elements, such as address bars, can cause unexpected shifting when using standard viewport units.
  Key changes:
     - Viewport Unit Migration: Replaced legacy vw and vh with modern dvw and dvh units for more robust responsive design across the application.
     - Small Viewport Adjustments: Utilized svh for fixed-position elements in app.css to ensure they remain within the visible area when browser toolbars are present.
     - Improved UI Positioning: Updated dialog and modal positioning in ui.css using dvh and dvw to ensure accurate centering regardless of browser UI state.
     - Structural Consistency: Applied dynamic viewport units to global variables in common.css and layout-critical selectors in app.css to prevent layout overflows.