### PR TITLE
feat(Wolfx): Wolfx API の WebSocket 切断時ページ内通知のタイプを error に変更

### DIFF
--- a/src/pages/scripts/ydits-web/services/wolfx/wolfx.js
+++ b/src/pages/scripts/ydits-web/services/wolfx/wolfx.js
@@ -191,7 +191,7 @@ export class Wolfx extends Service {
         if (!navigator.onLine) { return; }
 
         this.app.services.notify.showNotify({
-            type: Notify.types.message,
+            type: Notify.types.error,
             title: "WebSocket切断",
             body: "Wolfx JMA EEW WebSocket から切断しました。再接続試行中...",
         });


### PR DESCRIPTION
## Changes

### Feature

- #119 
  feat(Wolfx): Change WebSocket disconnection notification type to error
  Updates the notification type shown when the Wolfx JMA EEW WebSocket disconnects. By changing the type from message to error, the notification now correctly reflects the critical nature of the connection loss and provides better visual feedback to the user while reconnection is being attempted.
  Key changes:
     - Notification Type Update: Changed the Notify type from message to error for WebSocket disconnection events in the Wolfx service.
     - Improved Visual Feedback: Ensures that connection failures are prominently displayed as errors rather than standard informational messages.