### PR TITLE
fix(YditsWeb): デバッグオーバーレイの eew object の扱いに誤りがある問題を修正

### DIFF
--- a/src/pages/scripts/ydits-web/ydits-web.js
+++ b/src/pages/scripts/ydits-web/ydits-web.js
@@ -594,7 +594,7 @@ export class YditsWeb extends FirebaseApp {
 
         safecall(() => {
             let reports = "";
-            for (const [key, value] of Object.keys(this.services.eew.reports[this.services.eew.currentId])) {
+            for (const [key, value] of Object.entries(this.services.eew.reports[this.services.eew.currentId])) {
                 reports += `${key}: ${value}, `;
             }
             this.services.elementsManager.getElementById("debugOutputEewData").textContent = `Current EEW Data: ${reports}`;


### PR DESCRIPTION
## Changes

### Fix

- #124 
  fix(YditsWeb): Correct debug report iteration
  Fixes the EEW debug output generation by iterating over report entries instead of report keys, allowing both the report field names and values to be rendered correctly.
  Key changes:
    - **Use object entries**: Replaces `Object.keys(...)` with `Object.entries(...)` so destructuring receives `[key, value]` pairs as intended.
    - **Restore debug output values**: Ensures the current EEW data debug text includes each report value instead of producing incorrect key/value handling.