### PR TITLE
refactor(Map): `Map` クラスのリファクタリング

### DIFF
--- a/src/pages/scripts/ydits-web/services/map/map.js
+++ b/src/pages/scripts/ydits-web/services/map/map.js
@@ -18,6 +18,36 @@ import { Notify } from "../notify/notify.js";
  */
 export class Map extends Service {
     /**
+     * マップの初期位置
+     */
+    static DEFAULT_CENTER = [137.5930000, 36.0047000];
+
+    /**
+     * マップの初期ズームレベル
+     */
+    static DEFAULT_ZOOM = 4;
+
+    /**
+     * Turfで円を作成するためのデフォルトオプション
+     */
+    static DEFAULT_CIRCLE_OPTIONS = { steps: 64, units: "meters", propreties: { foo: "bar" } };
+
+    /**
+     * 雨雲レーダー(高解像度降水ナウキャスト/HRPNS)の各データを提供するJSONのURL
+     */
+    static #HRPNS_TIMES_URI = new URL("https://www.jma.go.jp/bosai/himawari/data/satimg/targetTimes_jp.json");
+
+    /**
+     * 台風予想進路図の各データを提供するJSONのURL
+     */
+    static #TROPICAL_CYCLONE_TARGET_URI = new URL("https://www.jma.go.jp/bosai/typhoon/data/targetTc.json");
+
+    /**
+     * MapTiler APIキー
+     */
+    static #MAPTILER_API_KEY = "3ft2uVdfAwtgfKQGIT8U";
+
+    /**
      * @param {YditsWeb} app
      */
     constructor(app) {
@@ -30,10 +60,8 @@ export class Map extends Service {
         });
 
         this.app = app;
-
-        this.typhoonLayerIds = [];
-        this.typhoonSourceIds = [];
-        this.typhoonMarkers = [];
+        this.$hrpnsTime = this.app.services.elementsManager.getElementById("hrpnsTime");
+        this.$hrpnsTimeText = document.querySelector("#hrpnsTime>.text") ?? document.createElement("div");
     }
 
     /**
@@ -43,66 +71,41 @@ export class Map extends Service {
      */
     app;
 
-    static DEFAULT_CENTER = [137.5930000, 36.0047000];
-    static DEFAULT_ZOOM = 4;
-    static HRPNS_TIMES_URI = "https://www.jma.go.jp/bosai/himawari/data/satimg/targetTimes_jp.json";
-    static TROPICAL_CYCLONE_TARGET_URI = "https://www.jma.go.jp/bosai/typhoon/data/targetTc.json";
-    static DEFAULT_CIRCLE_OPTIONS = { steps: 64, units: "meters", propreties: { foo: "bar" } };
-
     /**
-     * Element: 雨雲レーダー時刻
+     * HTMLElement: 雨雲レーダー時刻
      * @type {HTMLElement}
      */
-    get $hrpnsTime() {
-        if (!(this.#_$hrpnsTime instanceof HTMLElement)) {
-            this.#_$hrpnsTime = document.querySelector("#hrpnsTime");
-        }
-
-        return this.#_$hrpnsTime;
-    }
+    $hrpnsTime;
 
     /**
-     * Element: 雨雲レーダー時刻テキスト
+     * HTMLElement: 雨雲レーダー時刻テキスト
      * @type {HTMLElement}
      */
-    get $hrpnsTimeText() {
-        if (!(this.#_$hrpnsTimeText instanceof HTMLElement)) {
-            this.#_$hrpnsTimeText = document.querySelector("#hrpnsTime>.text");
-        }
-
-        return this.#_$hrpnsTimeText;
-    }
+    $hrpnsTimeText;
 
     /**
-     * 位置情報サービスがサポートされているかどうか
-     * @type {boolean}
+     * 台風予想進路図のレイヤーIDArray
+     * @type {Array<string>}
      */
-    get isGeolocationSupported() {
-        if (this.#_$isGeolocationSupported === undefined) {
-            this.#_$isGeolocationSupported = "geolocation" in navigator;
-        }
-
-        return this.#_$isGeolocationSupported;
-    }
+    typhoonLayerIds = [];
 
     /**
-     * 雨雲レーダー（高解像度降水ナウキャスト/HRPNS）の画像URLを取得する
-     * @param {string} baseTime
-     * @param {string} validTime
-     * @returns {string}
+     * 台風予想進路図のソースIDArray
+     * @type {Array<string>}
      */
-    hrpnsImageUri(baseTime, validTime) {
-        return `https://www.jma.go.jp/bosai/jmatile/data/nowc/${baseTime}/none/${validTime}/surf/hrpns/{z}/{x}/{y}.png`;
-    }
+    typhoonSourceIds = [];
 
     /**
-     * 台風予想進路図のURLを取得する
-     * @param {any} tropicalCycloneNumber
-     * @returns {string}
+     * 台風予想進路図のマーカーArray
+     * @type {Array<unknown>}
      */
-    tropicalCycloneForecastUrl(tropicalCycloneNumber) {
-        return `https://www.jma.go.jp/bosai/typhoon/data/${tropicalCycloneNumber}/forecast.json`;
-    }
+    typhoonMarkers = [];
+
+    /**
+     * マップ自動移動のカウント
+     * @type {number | null}
+     */
+    #autoMoveCount = null;
 
     /**
      * 初期化する
@@ -117,6 +120,10 @@ export class Map extends Service {
 
         await this.#initializeMaps();
 
+        if (!this.map) {
+            return;
+        }
+
         this.map.once("load", async () => {
             this.userPointImage = await this.map.loadImage('/images/user_point.png');
             this.regionImage = await this.map.loadImage('/images/hypocenter.png');
@@ -126,15 +133,40 @@ export class Map extends Service {
             await this.map.addImage(`eewRedionImage`, this.regionImage.data);
             await this.map.addImage(`typhoonCenterImage`, this.typhoonCenterImage.data);
 
-            await this.showHrpns();
-            await this.displayTyphoon();
+            await this.#displayHrpns();
+            await this.#displayTyphoon();
         });
 
-        if (!this.isGeolocationSupported) { return }
+        if (!this.app?.services?.geoLocation?.isSupported) { return }
 
         document.addEventListener("getLocation", async () => await this.updateUserPoint());
 
         this.app.displayInitializedNotify();
+    }
+
+    /**
+     * マップを移動する
+     * @param {L.LatLng} lngLat - 移動先の緯度経度
+     * @param {number} zoom - ズームレベル
+     * @returns {Promise<void>}
+     */
+    async setView(lngLat, zoom) {
+        await this.map.flyTo({
+            center: lngLat,
+            zoom: zoom,
+            speed: 3,
+            curve: 1,
+            bearing: 0,
+            pitch: 0,
+        });
+    }
+
+    /**
+     * マップを初期位置に移動する
+     * @returns {Promise<void>}
+     */
+    async setViewHome() {
+        await this.setView(Map.DEFAULT_CENTER, Map.DEFAULT_ZOOM);
     }
 
     /**
@@ -180,6 +212,163 @@ export class Map extends Service {
     }
 
     /**
+     * 緊急地震速報の描画を更新する
+     * @param {Date} dateNow
+     * @param {number} fps
+     * @returns {void}
+     */
+    updateEew(dateNow, fps) {
+        const isEewOnYahooKmoni = this.app.services.api.yahooKmoni?.isEew;
+        const eewReports = this.app.services.eew.reports;
+        const currentEewId = this.app.services.eew.currentId
+
+        if (!isEewOnYahooKmoni) {
+            if (!this.isDisplayHrpns) {
+                this.#displayHrpns();
+            }
+
+            if (!this.isDisplayTyphoon) {
+                this.#displayTyphoon();
+            }
+
+            this.#removeEewLayers();
+            return;
+        }
+
+        try {
+            this.#hideHrpns();
+            this.#hideTyphoon();
+
+            Object.keys(eewReports).forEach((id) => {
+                const report = this.app.services.eew.reports[id];
+
+                if (
+                    typeof id !== "string" ||
+                    report.isWarning ||
+                    !report.latitude ||
+                    !report.longitude ||
+                    !report.psWave
+                ) {
+                    return;
+                }
+
+                if (currentEewId === id) {
+                    if (!report.isMapInitialized) {
+                        if (!this.map.hasImage('eewRedionImage')) {
+                            return;
+                        }
+                        this.#addEewLayers(id);
+                    }
+
+                    this.app.services.eew.reports[id].latitude = this.app.services.eew.reports[id].latitude.replace("N", "");
+                    this.app.services.eew.reports[id].longitude = this.app.services.eew.reports[id].longitude.replace("E", "");
+
+                    this.app.services.eew.reports[id].sRadius = this.app.services.eew.reports[id].psWave.sRadius * 1000;
+                    this.app.services.eew.reports[id].pRadius = this.app.services.eew.reports[id].psWave.pRadius * 1000;
+
+                    if (this.app.services.eew.reports[id].sRadius != this.app.services.eew.reports[id].lastSWave) {
+                        this.app.services.eew.reports[id].sWaveInterval = (this.app.services.eew.reports[id].sRadius - this.app.services.eew.reports[id].lastSWave) / fps;
+                        this.app.services.eew.reports[id].lastSWave = this.app.services.eew.reports[id].sRadius;
+                        this.app.services.eew.reports[id].sWavePut = this.app.services.eew.reports[id].sRadius;
+                    } else if (this.app.services.eew.reports[id].sRadius == this.app.services.eew.reports[id].lastSWave) {
+                        if (this.app.services.eew.reports[id].sWaveInterval < 150 && this.app.services.eew.reports[id].sWaveInterval > 0) {
+                            this.app.services.eew.reports[id].sWavePut += this.app.services.eew.reports[id].sWaveInterval;
+                        }
+                    }
+
+                    if (this.app.services.eew.reports[id].pRadius != this.app.services.eew.reports[id].lastPWave) {
+                        this.app.services.eew.reports[id].pWaveInterval = (this.app.services.eew.reports[id].pRadius - this.app.services.eew.reports[id].lastPWave) / fps;
+                        this.app.services.eew.reports[id].lastPWave = this.app.services.eew.reports[id].pRadius;
+                        this.app.services.eew.reports[id].pWavePut = this.app.services.eew.reports[id].pRadius;
+                    } else if (this.app.services.eew.reports[id].pRadius == this.app.services.eew.reports[id].lastPWave) {
+                        if (this.app.services.eew.reports[id].pWaveInterval < 300 && this.app.services.eew.reports[id].pWaveInterval > 0) {
+                            this.app.services.eew.reports[id].pWavePut += this.app.services.eew.reports[id].pWaveInterval;
+                        }
+                    }
+                } else {
+                    if (this.app.services.eew.reports[id].sWaveInterval < 150 && this.app.services.eew.reports[id].sWaveInterval > 0) {
+                        this.app.services.eew.reports[id].sWavePut += this.app.services.eew.reports[id].sWaveInterval;
+                    }
+
+                    if (this.app.services.eew.reports[id].pWaveInterval < 300 && this.app.services.eew.reports[id].pWaveInterval > 0) {
+                        this.app.services.eew.reports[id].pWavePut += this.app.services.eew.reports[id].pWaveInterval;
+                    }
+                }
+
+                const REGION_LNGLAT = [this.app.services.eew.reports[id].longitude, this.app.services.eew.reports[id].latitude];
+                const sWaveCircleJSON = turf.circle(REGION_LNGLAT, this.app.services.eew.reports[id].sWavePut, Map.DEFAULT_CIRCLE_OPTIONS);
+                const pWaveCircleJSON = turf.circle(REGION_LNGLAT, this.app.services.eew.reports[id].pWavePut, Map.DEFAULT_CIRCLE_OPTIONS);
+
+                this.map.getSource(`eewRedionSource_${id}`).setData({
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            geometry: {
+                                type: 'Point',
+                                coordinates: REGION_LNGLAT,
+                            },
+                        },
+                    ],
+                });
+                this.map.getSource(`eewSWaveSource_${id}`).setData(sWaveCircleJSON);
+                this.map.getSource(`eewPWaveSource_${id}`).setData(pWaveCircleJSON);
+            });
+
+            if (this.app.services.settings.map.autoMove) {
+                this.#autoMoveMap(dateNow);
+            }
+        } catch (error) {
+            console.error(error);
+            // this.app.services.debugLogs.add("error", `[${this.name}]`, `EEW Map update error: ${error.stack}`);
+        }
+    }
+
+    /**
+     * 雨雲レーダー(高解像度降水ナウキャスト/HRPNS)を更新する
+     * @returns {Promise<void>}
+     */
+    async updateHrpns() {
+        if (!this.isDisplayHrpns) {
+            return;
+        }
+
+        this.#displayHrpns();
+    }
+
+    /**
+     * 台風予想進路図の描画を更新する
+     * @returns {Promise<void>}
+     */
+    async updateTyphoon() {
+        await this.#hideTyphoon();
+        await this.#displayTyphoon();
+    }
+
+    /**
+     * マップインスタンスを初期化する
+     * @returns {Promise<void>}
+     */
+    async #initializeMaps() {
+        try {
+            this.map = await new maplibregl.Map({
+                container: "map",
+                style: `https://api.maptiler.com/maps/ba979b60-0cf8-4087-8cdc-5bb919540c08/style.json?key=${Map.#MAPTILER_API_KEY}`,
+                center: Map.DEFAULT_CENTER,
+                zoom: Map.DEFAULT_ZOOM,
+                maxZoom: 9,
+                minZoom: 3,
+                attributionControl: {
+                    compact: true,
+                    customAttribution: "© 気象庁",
+                },
+            });
+        } catch (error) {
+            throw new Error(`Failed to initialize map: ${error instanceof Error ? error.message : error}`)
+        }
+    }
+
+    /**
      * ユーザーポイントのソースとレイヤーを作成する
      * @param {any} lngLat - ユーザーポイントの緯度経度
      * @returns {Promise<void>}
@@ -219,45 +408,125 @@ export class Map extends Service {
     }
 
     /**
-     * 日時文字列をフォーマットする
-     * @param {string} datetime - 'yyyyMMDDHHmm' 形式の日時文字列
-     * @returns {string} - 'HH:mm' 形式の日時文字列
+     * マップを自動で移動する
+     * @param {Date} dateNow - 現在の日時
+     * @return {void}
      */
-    #formatDatetime(datetime) {
-        const year = datetime.slice(0, 4);
-        const month = datetime.slice(4, 6) - 1;
-        const day = datetime.slice(6, 8);
-        const hour = datetime.slice(8, 10);
-        const minute = datetime.slice(10, 12);
-        const date = new Date(Date.UTC(year, month, day, hour, minute));
-        return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-    }
-
-    /**
-     * 雨雲レーダー（高解像度降水ナウキャスト/HRPNS）を更新する
-     * @returns {Promise<void>}
-     */
-    async updateHrpns() {
-        if (!this.isDisplayHrpns) {
-            return;
+    #autoMoveMap(dateNow) {
+        if (dateNow - this.#autoMoveCount >= 3000) {
+            const report = this.app.services.eew.reports[this.app.services.eew.currentId];
+            if (report.pWavePut >= 300000) {
+                this.setView([report.longitude, report.latitude], 4);
+            } else if (report.pWavePut > 0) {
+                this.setView([report.longitude, report.latitude], 5);
+            }
+            this.#autoMoveCount = dateNow;
         }
-
-        this.showHrpns();
     }
 
     /**
-     * 雨雲レーダー（高解像度降水ナウキャスト/HRPNS）を表示する
+     * 緊急地震速報のレイヤーを追加する
+     * @param {string} id - EEWのID
      * @returns {Promise<void>}
      */
-    async showHrpns() {
-        await this.hideHrpns();
+    async #addEewLayers(id) {
+        await this.#hideHrpns();
+        await this.#hideTyphoon();
 
-        if (this.app.services.api.yahooKmoni.isEew) return;
+        const sWaveCircleJSON = turf.circle([0, 0], 0, Map.DEFAULT_CIRCLE_OPTIONS);
+        const pWaveCircleJSON = turf.circle([0, 0], 0, Map.DEFAULT_CIRCLE_OPTIONS);
+
+        this.map.addSource(`eewRedionSource_${id}`, {
+            type: 'geojson',
+            data: {
+                type: 'FeatureCollection',
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [0, 0],
+                        },
+                    },
+                ],
+            },
+        });
+
+        this.map.addLayer({
+            id: `eewRedion_${id}`,
+            type: "symbol",
+            source: `eewRedionSource_${id}`,
+            layout: {
+                "icon-image": `eewRedionImage`,
+                "icon-size": 0.25,
+                "icon-allow-overlap": true,
+            },
+        });
+
+        this.map.addSource(`eewSWaveSource_${id}`, {
+            type: "geojson",
+            data: sWaveCircleJSON,
+        });
+
+        this.map.addLayer({
+            id: `eewSWave_${id}`,
+            type: "line",
+            source: `eewSWaveSource_${id}`,
+            paint: {
+                "line-width": 1,
+                "line-color": "#ff4020",
+            },
+        });
+
+        this.map.addSource(`eewPWaveSource_${id}`, {
+            type: "geojson",
+            data: pWaveCircleJSON,
+        });
+
+        this.map.addLayer({
+            id: `eewPWave_${id}`,
+            type: "line",
+            source: `eewPWaveSource_${id}`,
+            paint: {
+                "line-width": 1,
+                "line-color": "#4080ff",
+            },
+        });
+
+        this.app.services.eew.reports[id].isMapInitialized = true;
+    }
+
+    /**
+     * 緊急地震速報のレイヤーを削除する
+     * @returns {void}
+     */
+    #removeEewLayers() {
+        Object.keys(this.app.services.eew.reports).forEach(id => {
+            if (id !== "undefined" && !this.app.services.eew.reports[id].isWarning) {
+                this.map.removeLayer(`eewRedion_${id}`);
+                this.map.removeLayer(`eewSWave_${id}`);
+                this.map.removeLayer(`eewPWave_${id}`);
+                this.map.removeSource(`eewRedionSource_${id}`);
+                this.map.removeSource(`eewSWaveSource_${id}`);
+                this.map.removeSource(`eewPWaveSource_${id}`);
+                delete this.app.services.eew.reports[id];
+            }
+        });
+    }
+
+    /**
+     * 雨雲レーダー(高解像度降水ナウキャスト/HRPNS)を表示する
+     * @returns {Promise<void>}
+     */
+    async #displayHrpns() {
+        await this.#hideHrpns();
+
+        if (this.app.services.api.yahooKmoni?.isEew) return;
 
         this.isDisplayHrpns = true;
 
         this.hrpnsLatestTargetTime = await this.getHrpnsTargetTime();
-        const url = this.hrpnsImageUri(this.hrpnsLatestTargetTime.basetime, this.hrpnsLatestTargetTime.validtime);
+        const url = this.#generateHrpnsImageUri(this.hrpnsLatestTargetTime.basetime, this.hrpnsLatestTargetTime.validtime);
 
         const zoomPairs = [2, 4, 6, 8, 10];
 
@@ -315,10 +584,10 @@ export class Map extends Service {
     }
 
     /**
-     * 雨雲レーダー（高解像度降水ナウキャスト/HRPNS）を非表示する
+     * 雨雲レーダー(高解像度降水ナウキャスト/HRPNS)を非表示する
      * @returns {Promise<void>}
      */
-    async hideHrpns() {
+    async #hideHrpns() {
         this.isDisplayHrpns = false;
 
         const zoomPairs = [2, 4, 6, 8, 10];
@@ -337,6 +606,16 @@ export class Map extends Service {
     }
 
     /**
+     * 雨雲レーダー(高解像度降水ナウキャスト/HRPNS)の画像URLを生成する
+     * @param {string} baseTime
+     * @param {string} validTime
+     * @returns {string}
+     */
+    #generateHrpnsImageUri(baseTime, validTime) {
+        return `https://www.jma.go.jp/bosai/jmatile/data/nowc/${baseTime}/none/${validTime}/surf/hrpns/{z}/{x}/{y}.png`;
+    }
+
+    /**
      * 雨雲レーダー（高解像度降水ナウキャスト/HRPNS）の最新URLを返す
      * @returns {Promise<any>}
      */
@@ -352,7 +631,7 @@ export class Map extends Service {
      */
     async fetchHrpnsTargetTime() {
         try {
-            const response = await fetch(Map.HRPNS_TIMES_URI);
+            const response = await fetch(Map.#HRPNS_TIMES_URI);
             if (!response.ok) {
                 throw new Error(`Error fetching rain map data: Status ${response.status}`);
             }
@@ -364,30 +643,21 @@ export class Map extends Service {
     }
 
     /**
-     * 台風情報（予想進路図）を更新する
-     * @returns {Promise<void>}
-     */
-    async updateTyphoon() {
-        await this.removeTyphoon();
-        await this.displayTyphoon();
-    }
-
-    /**
      * 台風情報（予想進路図）を表示する
      * @returns {Promise<void>}
      */
-    async displayTyphoon() {
-        this.removeTyphoon();
+    async #displayTyphoon() {
+        this.#hideTyphoon();
 
         if (this.app.services.api.yahooKmoni.isEew) return;
 
         this.isDisplayTyphoon = true;
-        this.tropicalCycloneLatestTarget = await this.getTropicalCycloneTarget();
+        this.tropicalCycloneLatestTarget = await this.#getTropicalCycloneTarget();
         if (!this.tropicalCycloneLatestTarget) return;
 
 
         this.tropicalCycloneLatestTarget.forEach(async (target) => {
-            const url = this.tropicalCycloneForecastUrl(target);
+            const url = this.#generateTropicalCycloneForecastUrl(target);
             const typhoonId = target;
 
             let data = await fetch(url);
@@ -400,8 +670,8 @@ export class Map extends Service {
 
                 if (analysisData && analysisData.galeWarningArea) {
                     const typhoonNumber = titleData.typhoonNumber.slice(-2).replace(/^0+/, '');
-                    this.addWarningAreas(analysisData.stormWarningArea, analysisData.galeWarningArea, typhoonId);
-                    this.addTyphoonNumber(
+                    this.#addTyphoonWarningAreas(analysisData.stormWarningArea, analysisData.galeWarningArea, typhoonId);
+                    this.#addTyphoonNumber(
                         typhoonId,
                         [analysisData.galeWarningArea.center?.[1], analysisData.galeWarningArea.center?.[0]],
                         analysisData.center,
@@ -409,7 +679,7 @@ export class Map extends Service {
                     );
                 }
 
-                forecasts.forEach((forecast, index) => this.addForecastCircles(forecast, `${typhoonId}_${index}`));
+                forecasts.forEach((forecast, index) => this.#addTyphoonForecastCircles(forecast, `${typhoonId}_${index}`));
 
                 if (analysisData && analysisData.track && analysisData.track.typhoon) {
                     if (analysisData.center) {
@@ -501,12 +771,80 @@ export class Map extends Service {
     }
 
     /**
+     * 台風情報（予想進路図）を非表示する
+     * @returns {Promise<void>}
+     */
+    async #hideTyphoon() {
+        this.typhoonLayerIds.forEach(id => {
+            if (this.map.getLayer(id)) {
+                this.map.removeLayer(id);
+            }
+        });
+        this.typhoonSourceIds.forEach(id => {
+            if (this.map.getSource(id)) {
+                this.map.removeSource(id);
+            }
+        });
+        this.typhoonMarkers.forEach(marker => marker.remove());
+
+        this.typhoonLayerIds = [];
+        this.typhoonSourceIds = [];
+        this.typhoonMarkers = [];
+        this.isDisplayTyphoon = false;
+    }
+
+    /**
+     * 台風予想進路図のURLを生成する
+     * @param {string} tropicalCycloneNumber
+     * @returns {string}
+     */
+    #generateTropicalCycloneForecastUrl(tropicalCycloneNumber) {
+        return `https://www.jma.go.jp/bosai/typhoon/data/${tropicalCycloneNumber}/forecast.json`;
+    }
+
+    /**
+     * 台風情報（予想進路図）の最新URLを返す
+     * @returns {Promise<any>}
+     */
+    async #getTropicalCycloneTarget() {
+        try {
+            const tcs = await this.#fetchTropicalCycloneTarget();
+            if (!tcs || tcs.length <= 0) return null;
+
+            const datas = tcs.map(item => item.tropicalCyclone);
+
+            if (datas) { return datas; }
+            else { return null; }
+        } catch (error) {
+            console.error("An error occurred when parsing tropical cyclone JSON data: ", error);
+        }
+    }
+
+    /**
+     * 台風情報（予想進路図）のターゲットURLを取得する
+     * @returns {Promise<any>}
+     */
+    async #fetchTropicalCycloneTarget() {
+        try {
+            const response = await fetch(Map.#TROPICAL_CYCLONE_TARGET_URI);
+            if (!response.ok) {
+                throw new Error(`Error fetching rain map data: Status ${response.status}`);
+            }
+            const data = await response.json();
+            return data;
+        } catch (error) {
+            console.error(`Error fetching rain map data: ${error}`);
+            return null;
+        }
+    }
+
+    /**
      * 予報円を追加する
      * @param {object} forecast - 予報円の情報
      * @param {string} forecastId - 予報のユニークID
      * @return {Promise<void>}
      */
-    async addForecastCircles(forecast, forecastId) {
+    async #addTyphoonForecastCircles(forecast, forecastId) {
         if (forecast && forecast.center && forecast.probabilityCircle) {
             const center = [forecast.center[1], forecast.center[0]];
             const radius = forecast.probabilityCircle.radius;
@@ -619,7 +957,7 @@ export class Map extends Service {
      * @param {any} typhoonCenter
      * @param {number} typhoonNumber
      */
-    async addTyphoonNumber(typhoonId, galeWarningAreaCenter, typhoonCenter, typhoonNumber) {
+    async #addTyphoonNumber(typhoonId, galeWarningAreaCenter, typhoonCenter, typhoonNumber) {
         const center = galeWarningAreaCenter ?? typhoonCenter;
 
         const numberSourceId = `typhoonNumberSource_${typhoonId}`;
@@ -659,11 +997,12 @@ export class Map extends Service {
 
     /**
      * 暴風域と強風域を追加する
+     * @param {object} stormWarningArea - 暴風域の情報
      * @param {object} galeWarningArea - 強風域の情報
      * @param {string} typhoonId - 台風のユニークID
      * @return {Promise<void>}
      */
-    async addWarningAreas(stormWarningArea, galeWarningArea, typhoonId) {
+    async #addTyphoonWarningAreas(stormWarningArea, galeWarningArea, typhoonId) {
         if (galeWarningArea) {
             const galeWarningAreaCenter = [galeWarningArea.center?.[1], galeWarningArea.center?.[0]];
             const galeWarningAreaRadius = galeWarningArea.radius;
@@ -740,365 +1079,17 @@ export class Map extends Service {
     }
 
     /**
-     * 台風情報（予想進路図）を非表示する
-     * @returns {Promise<void>}
+     * 日時文字列をフォーマットする
+     * @param {string} datetime - 'yyyyMMDDHHmm' 形式の日時文字列
+     * @returns {string} - 'HH:mm' 形式の日時文字列
      */
-    async removeTyphoon() {
-        this.typhoonLayerIds.forEach(id => {
-            if (this.map.getLayer(id)) {
-                this.map.removeLayer(id);
-            }
-        });
-        this.typhoonSourceIds.forEach(id => {
-            if (this.map.getSource(id)) {
-                this.map.removeSource(id);
-            }
-        });
-        this.typhoonMarkers.forEach(marker => marker.remove());
-
-        this.typhoonLayerIds = [];
-        this.typhoonSourceIds = [];
-        this.typhoonMarkers = [];
-        this.isDisplayTyphoon = false;
+    #formatDatetime(datetime) {
+        const year = datetime.slice(0, 4);
+        const month = datetime.slice(4, 6) - 1;
+        const day = datetime.slice(6, 8);
+        const hour = datetime.slice(8, 10);
+        const minute = datetime.slice(10, 12);
+        const date = new Date(Date.UTC(year, month, day, hour, minute));
+        return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
     }
-
-    /**
-     * 台風情報（予想進路図）の最新URLを返す
-     * @returns {Promise<any>}
-     */
-    async getTropicalCycloneTarget() {
-        try {
-            const tcs = await this.fetchTropicalCycloneTarget();
-            if (!tcs || tcs.length <= 0) return null;
-
-            const datas = tcs.map(item => item.tropicalCyclone);
-
-            if (datas) { return datas; }
-            else { return null; }
-        } catch (error) {
-            console.error("An error occurred when parsing tropical cyclone JSON data: ", error);
-        }
-    }
-
-    /**
-     * 台風情報（予想進路図）のターゲットURLを取得する
-     * @returns {Promise<any>}
-     */
-    async fetchTropicalCycloneTarget() {
-        try {
-            const response = await fetch(Map.TROPICAL_CYCLONE_TARGET_URI);
-            if (!response.ok) {
-                throw new Error(`Error fetching rain map data: Status ${response.status}`);
-            }
-            const data = await response.json();
-            return data;
-        } catch (error) {
-            console.error(`Error fetching rain map data: ${error}`);
-            return null;
-        }
-    }
-
-    /**
-     * マップの描画を更新する
-     * @param {any} dateNow
-     * @returns {void}
-     */
-    update(dateNow, fps) {
-        const isEewOnYahooKmoni = this.app.services.api.yahooKmoni.isEew;
-        const eewReports = this.app.services.eew.reports;
-        const currentEewId = this.app.services.eew.currentId
-
-        if (!isEewOnYahooKmoni) {
-            if (!this.isDisplayHrpns) {
-                this.showHrpns();
-            }
-
-            if (!this.isDisplayTyphoon) {
-                this.displayTyphoon();
-            }
-
-            this.#clearEewLayers();
-            return;
-        }
-
-        try {
-            this.hideHrpns();
-            this.removeTyphoon();
-
-            Object.keys(eewReports).forEach((id) => {
-                const report = this.app.services.eew.reports[id];
-
-                if (
-                    typeof id !== "string" ||
-                    report.isWarning ||
-                    !report.latitude ||
-                    !report.longitude ||
-                    !report.psWave
-                ) {
-                    return;
-                }
-
-                if (currentEewId === id) {
-                    if (!report.isMapInitialized) {
-                        if (!this.map.hasImage('eewRedionImage')) {
-                            return;
-                        }
-                        this.#addEewLayers(id);
-                    }
-
-                    this.app.services.eew.reports[id].latitude = this.app.services.eew.reports[id].latitude.replace("N", "");
-                    this.app.services.eew.reports[id].longitude = this.app.services.eew.reports[id].longitude.replace("E", "");
-
-                    this.app.services.eew.reports[id].sRadius = this.app.services.eew.reports[id].psWave.sRadius * 1000;
-                    this.app.services.eew.reports[id].pRadius = this.app.services.eew.reports[id].psWave.pRadius * 1000;
-
-                    if (this.app.services.eew.reports[id].sRadius != this.app.services.eew.reports[id].lastSWave) {
-                        this.app.services.eew.reports[id].sWaveInterval = (this.app.services.eew.reports[id].sRadius - this.app.services.eew.reports[id].lastSWave) / fps;
-                        this.app.services.eew.reports[id].lastSWave = this.app.services.eew.reports[id].sRadius;
-                        this.app.services.eew.reports[id].sWavePut = this.app.services.eew.reports[id].sRadius;
-                    } else if (this.app.services.eew.reports[id].sRadius == this.app.services.eew.reports[id].lastSWave) {
-                        if (this.app.services.eew.reports[id].sWaveInterval < 150 && this.app.services.eew.reports[id].sWaveInterval > 0) {
-                            this.app.services.eew.reports[id].sWavePut += this.app.services.eew.reports[id].sWaveInterval;
-                        }
-                    }
-
-                    if (this.app.services.eew.reports[id].pRadius != this.app.services.eew.reports[id].lastPWave) {
-                        this.app.services.eew.reports[id].pWaveInterval = (this.app.services.eew.reports[id].pRadius - this.app.services.eew.reports[id].lastPWave) / fps;
-                        this.app.services.eew.reports[id].lastPWave = this.app.services.eew.reports[id].pRadius;
-                        this.app.services.eew.reports[id].pWavePut = this.app.services.eew.reports[id].pRadius;
-                        this.#loopCount = dateNow;
-                    } else if (this.app.services.eew.reports[id].pRadius == this.app.services.eew.reports[id].lastPWave) {
-                        if (this.app.services.eew.reports[id].pWaveInterval < 300 && this.app.services.eew.reports[id].pWaveInterval > 0) {
-                            this.app.services.eew.reports[id].pWavePut += this.app.services.eew.reports[id].pWaveInterval;
-                        }
-                    }
-                } else {
-                    if (this.app.services.eew.reports[id].sWaveInterval < 150 && this.app.services.eew.reports[id].sWaveInterval > 0) {
-                        this.app.services.eew.reports[id].sWavePut += this.app.services.eew.reports[id].sWaveInterval;
-                    }
-
-                    if (this.app.services.eew.reports[id].pWaveInterval < 300 && this.app.services.eew.reports[id].pWaveInterval > 0) {
-                        this.app.services.eew.reports[id].pWavePut += this.app.services.eew.reports[id].pWaveInterval;
-                    }
-                }
-
-                const REGION_LNGLAT = [this.app.services.eew.reports[id].longitude, this.app.services.eew.reports[id].latitude];
-                const sWaveCircleJSON = turf.circle(REGION_LNGLAT, this.app.services.eew.reports[id].sWavePut, Map.DEFAULT_CIRCLE_OPTIONS);
-                const pWaveCircleJSON = turf.circle(REGION_LNGLAT, this.app.services.eew.reports[id].pWavePut, Map.DEFAULT_CIRCLE_OPTIONS);
-
-                this.map.getSource(`eewRedionSource_${id}`).setData({
-                    type: 'FeatureCollection',
-                    features: [
-                        {
-                            type: 'Feature',
-                            geometry: {
-                                type: 'Point',
-                                coordinates: REGION_LNGLAT,
-                            },
-                        },
-                    ],
-                });
-                this.map.getSource(`eewSWaveSource_${id}`).setData(sWaveCircleJSON);
-                this.map.getSource(`eewPWaveSource_${id}`).setData(pWaveCircleJSON);
-            });
-
-            if (this.app.services.settings.map.autoMove) {
-                this.#autoMoveMap(dateNow);
-            }
-        } catch (error) {
-            console.error(error);
-            // this.app.services.debugLogs.add("error", `[${this.name}]`, `EEW Map update error: ${error.stack}`);
-        }
-    }
-
-    /**
-     * マップを自動で移動する
-     * @param {number} dateNow - 現在の日時
-     * @return {void}
-     */
-    #autoMoveMap(dateNow) {
-        if (dateNow - this.#autoMoveCount >= 3000) {
-            const report = this.app.services.eew.reports[this.app.services.eew.currentId];
-            if (report.pWavePut >= 300000) {
-                this.setView([report.longitude, report.latitude], 4);
-            } else if (report.pWavePut > 0) {
-                this.setView([report.longitude, report.latitude], 5);
-            }
-            this.#autoMoveCount = dateNow;
-        }
-    }
-
-    /**
-     * 緊急地震速報（EEW）のレイヤーを追加する
-     * @param {string} id - EEWのID
-     * @returns {void}
-     */
-    async #addEewLayers(id) {
-        await this.hideHrpns();
-        await this.removeTyphoon();
-
-        const sWaveCircleJSON = turf.circle([0, 0], 0, Map.DEFAULT_CIRCLE_OPTIONS);
-        const pWaveCircleJSON = turf.circle([0, 0], 0, Map.DEFAULT_CIRCLE_OPTIONS);
-
-        this.map.addSource(`eewRedionSource_${id}`, {
-            type: 'geojson',
-            data: {
-                type: 'FeatureCollection',
-                features: [
-                    {
-                        type: 'Feature',
-                        geometry: {
-                            type: 'Point',
-                            coordinates: [0, 0],
-                        },
-                    },
-                ],
-            },
-        });
-
-        this.map.addLayer({
-            id: `eewRedion_${id}`,
-            type: "symbol",
-            source: `eewRedionSource_${id}`,
-            layout: {
-                "icon-image": `eewRedionImage`,
-                "icon-size": 0.25,
-                "icon-allow-overlap": true,
-            },
-        });
-
-        this.map.addSource(`eewSWaveSource_${id}`, {
-            type: "geojson",
-            data: sWaveCircleJSON,
-        });
-
-        this.map.addLayer({
-            id: `eewSWave_${id}`,
-            type: "line",
-            source: `eewSWaveSource_${id}`,
-            paint: {
-                "line-width": 1,
-                "line-color": "#ff4020",
-            },
-        });
-
-        this.map.addSource(`eewPWaveSource_${id}`, {
-            type: "geojson",
-            data: pWaveCircleJSON,
-        });
-
-        this.map.addLayer({
-            id: `eewPWave_${id}`,
-            type: "line",
-            source: `eewPWaveSource_${id}`,
-            paint: {
-                "line-width": 1,
-                "line-color": "#4080ff",
-            },
-        });
-
-        this.app.services.eew.reports[id].isMapInitialized = true;
-    }
-
-    /**
-     * 緊急地震速報（EEW）のレイヤーをクリアする
-     * @returns {void}
-     */
-    #clearEewLayers() {
-        Object.keys(this.app.services.eew.reports).forEach(id => {
-            if (id !== "undefined" && !this.app.services.eew.reports[id].isWarning) {
-                this.map.removeLayer(`eewRedion_${id}`);
-                this.map.removeLayer(`eewSWave_${id}`);
-                this.map.removeLayer(`eewPWave_${id}`);
-                this.map.removeSource(`eewRedionSource_${id}`);
-                this.map.removeSource(`eewSWaveSource_${id}`);
-                this.map.removeSource(`eewPWaveSource_${id}`);
-                delete this.app.services.eew.reports[id];
-            }
-        });
-    }
-
-    /**
-     * マップを移動する
-     * @param {L.LatLng} latLng - 移動先の緯度経度
-     * @param {number} zoom - ズームレベル
-     * @returns {Promise<void>}
-     */
-    async setView(lngLat, zoom) {
-        await this.map.flyTo({
-            center: lngLat,
-            zoom: zoom,
-            speed: 2.0,
-            curve: 1.0,
-            bearing: 0,
-            pitch: 0,
-        });
-    }
-
-    /**
-     * マップを初期位置に移動する
-     * @returns {Promise<void>}
-     */
-    async setViewHome() {
-        await this.setView(Map.DEFAULT_CENTER, Map.DEFAULT_ZOOM);
-    }
-
-    /**
-     * マップインスタンスを初期化する
-     * @returns {Promise<void>}
-     */
-    async #initializeMaps() {
-        try {
-            this.map = await new maplibregl.Map({
-                container: "map",
-                style: `https://api.maptiler.com/maps/ba979b60-0cf8-4087-8cdc-5bb919540c08/style.json?key=${Map.#MAPTILER_API_KEY}`,
-                center: Map.DEFAULT_CENTER,
-                zoom: Map.DEFAULT_ZOOM,
-                maxZoom: 9,
-                minZoom: 3,
-                attributionControl: {
-                    compact: true,
-                    customAttribution: "© 気象庁",
-                },
-            });
-        } catch (error) {
-            throw new Error(`Could not initialize map: ${error.message}`, { error: error.stack });
-        }
-    }
-
-    /**
-     * MapTiler APIキー
-     * @type {string}
-     */
-    static #MAPTILER_API_KEY = "3ft2uVdfAwtgfKQGIT8U";
-
-    /**
-     * マップのループカウント
-     * @type {number}
-     */
-    #loopCount = -1;
-
-    /**
-     * マップ自動移動のカウント
-     * @type {number | null}
-     */
-    #autoMoveCount = null;
-
-    /**
-     * Element: 雨雲レーダー時刻
-     * @type {HTMLElement}
-     */
-    #_$hrpnsTime;
-
-    /**
-     * Element: 雨雲レーダー時刻テキスト
-     * @type {HTMLElement}
-     */
-    #_$hrpnsTimeText;
-
-    /**
-     * 位置情報サービスがサポートされているかどうか
-     * @type {boolean}
-     */
-    #_$isGeolocationSupported;
 }

--- a/src/pages/scripts/ydits-web/ydits-web.js
+++ b/src/pages/scripts/ydits-web/ydits-web.js
@@ -499,7 +499,7 @@ export class YditsWeb extends FirebaseApp {
 
         this.#calcFps(timeNowMs);
         this.#renderFps(timeNowMs);
-        this.services.map.update(timeNow, this.#fps);
+        this.services.map.updateEew(timeNow, this.#fps);
 
         requestAnimationFrame(() => this.#mainloop());
     }


### PR DESCRIPTION
## Changes

### Refactor

- #126 
  refactor(Map): Encapsulate map rendering workflows
  Reorganizes the map service by separating EEW, HRPNS, and typhoon rendering responsibilities into clearer public update methods and private helper methods.
  Key changes:
    - **Encapsulate map internals**: Converts JMA endpoint constants, URL builders, layer display/hide operations, typhoon drawing helpers, and EEW layer cleanup into private class members.
    - **Clarify EEW update flow**: Renames the main map update entry point to `updateEew` and updates the application main loop to call the new method.
    - **Improve initialization structure**: Moves map constants and MapTiler configuration to the top of the class, initializes HRPNS DOM references in the constructor, and guards against missing map initialization.
    - **Separate weather layer refreshes**: Keeps HRPNS and typhoon refresh behavior available through public `updateHrpns` and `updateTyphoon` methods while hiding their rendering details.