### PR TITLE
perf: `modulepreload` を指定する

### DIFF
--- a/src/pages/debug-logs/index.html
+++ b/src/pages/debug-logs/index.html
@@ -24,7 +24,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
 
     <noscript>
-        <meta http-equiv="refresh" content="0; URL=../noscript/">
+        <meta http-equiv="refresh" content="0; URL=/noscript/">
     </noscript>
 
     <!-- OGP -->
@@ -49,6 +49,7 @@
     <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png" title="YDITS for Web">
 
     <!-- Manifest -->
+    <link rel="modulepreload" href="/scripts/ydits-web/sw.js">
     <link rel="manifest" href="/ydits-web.webmanifest">
 
     <!-- Fonts -->
@@ -62,6 +63,92 @@
     <link rel="stylesheet" href="/styles/ui.css">
     <link rel="stylesheet" href="/styles/app.css">
     <link rel="stylesheet" href="./styles/index.css">
+
+    <!-- Preloads -->
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.1.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.0.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/render.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/app/app.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/component/component.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/element.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/elements.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/a.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/article.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/aside.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/footer.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/form.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h1.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h2.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h3.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h4.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h5.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h6.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/head.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/header.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/nav.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ol.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/p.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/script.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/search.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/section.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/span.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/strong.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/style.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/title.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ul.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-app.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-analytics.js" crossorigin>
+
+    <link rel="modulepreload" href="/scripts/common.js">
+    <link rel="modulepreload" href="/scripts/main.js">
+    <link rel="modulepreload" href="/scripts/packages/app-creator/src/app.js">
+    <link rel="modulepreload" href="/scripts/packages/app-creator/src/service.js">
+    <link rel="modulepreload" href="/scripts/packages/firebase-app-creator/src/app.js">
+    <link rel="modulepreload" href="/scripts/packages/popup-dialog/src/popup-dialog.js">
+    <link rel="modulepreload" href="/scripts/packages/safecaller/src/safecaller.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/ydits-web.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/firebase-config.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/api.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/dmdata.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/p2pquake.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/yahoo-kmoni.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/colors/colors.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/datetime/datetime.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/debug-logs/debug-logs.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/eew/eew.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/elements/elements.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/eqinfo/eqinfo.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/geolocation/geolocation.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/intensity/intensity.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/jma/jma-data-feed.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/local-storage/local-storage.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/map/map.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/notify/notify.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/push-notify/push-notify.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/service-worker/service-worker.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/settings/settings.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/sounds/sounds.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/wolfx.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/jma-eew-rest.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/jma-eew-websocket.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/heart-beat.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew-warn-area.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew-warn-areas.js">
 
     <!-- Scripts -->
     <script src="/scripts/common.js" type="module"></script>

--- a/src/pages/eqhistory/index.html
+++ b/src/pages/eqhistory/index.html
@@ -49,6 +49,7 @@
     <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png" title="YDITS for Web">
 
     <!-- Manifest -->
+    <link rel="modulepreload" href="/scripts/ydits-web/sw.js">
     <link rel="manifest" href="/ydits-web.webmanifest">
 
     <!-- Fonts -->
@@ -61,6 +62,92 @@
     <link rel="stylesheet" href="/styles/common.css">
     <link rel="stylesheet" href="/styles/ui.css">
     <link rel="stylesheet" href="/styles/app.css">
+
+    <!-- Preloads -->
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.1.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.0.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/render.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/app/app.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/component/component.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/element.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/elements.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/a.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/article.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/aside.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/footer.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/form.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h1.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h2.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h3.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h4.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h5.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h6.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/head.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/header.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/nav.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ol.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/p.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/script.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/search.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/section.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/span.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/strong.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/style.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/title.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ul.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-app.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-analytics.js" crossorigin>
+
+    <link rel="modulepreload" href="/scripts/common.js">
+    <link rel="modulepreload" href="/scripts/main.js">
+    <link rel="modulepreload" href="/scripts/packages/app-creator/src/app.js">
+    <link rel="modulepreload" href="/scripts/packages/app-creator/src/service.js">
+    <link rel="modulepreload" href="/scripts/packages/firebase-app-creator/src/app.js">
+    <link rel="modulepreload" href="/scripts/packages/popup-dialog/src/popup-dialog.js">
+    <link rel="modulepreload" href="/scripts/packages/safecaller/src/safecaller.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/ydits-web.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/firebase-config.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/api.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/dmdata.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/p2pquake.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/api/yahoo-kmoni.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/colors/colors.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/datetime/datetime.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/debug-logs/debug-logs.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/eew/eew.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/elements/elements.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/eqinfo/eqinfo.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/geolocation/geolocation.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/intensity/intensity.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/jma/jma-data-feed.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/local-storage/local-storage.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/map/map.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/notify/notify.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/push-notify/push-notify.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/service-worker/service-worker.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/settings/settings.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/sounds/sounds.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/wolfx.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/jma-eew-rest.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/jma-eew-websocket.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/heart-beat.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew-warn-area.js">
+    <link rel="modulepreload" href="/scripts/ydits-web/services/wolfx/data/jma-eew-warn-areas.js">
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -37,6 +37,10 @@
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 
+    <!-- Manifest -->
+    <link rel="modulepreload" href="./scripts/ydits-web/sw.js">
+    <link rel="manifest" href="./ydits-web.webmanifest">
+
     <!-- Preconnects -->
     <link rel="preconnect" href="https://cdn.yoneyo.com">
     <link rel="preconnect" href="https://cdn.ydits.net">
@@ -47,9 +51,6 @@
     <link rel="shortcut icon" type="image/png" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <link rel="apple-touch-icon-precomposed" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <link rel="fluid-icon" href="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png" title="YDITS for Web">
-
-    <!-- Manifest -->
-    <link rel="manifest" href="./ydits-web.webmanifest">
 
     <!-- Fonts -->
     <link rel="stylesheet" href="https://cdn.yoneyo.com/styles/local-noto-sans-jp.css">
@@ -62,6 +63,92 @@
     <link rel="stylesheet" href="./styles/common.css">
     <link rel="stylesheet" href="./styles/ui.css">
     <link rel="stylesheet" href="./styles/app.css">
+
+    <!-- Preloads -->
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.1.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.0.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/render.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/app/app.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/component/component.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/element.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/elements.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/a.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/article.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/aside.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/footer.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/form.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h1.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h2.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h3.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h4.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h5.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h6.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/head.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/header.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/nav.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ol.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/p.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/script.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/search.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/section.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/span.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/strong.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/style.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/title.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ul.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-app.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-analytics.js" crossorigin>
+
+    <link rel="modulepreload" href="./scripts/common.js">
+    <link rel="modulepreload" href="./scripts/main.js">
+    <link rel="modulepreload" href="./scripts/packages/app-creator/src/app.js">
+    <link rel="modulepreload" href="./scripts/packages/app-creator/src/service.js">
+    <link rel="modulepreload" href="./scripts/packages/firebase-app-creator/src/app.js">
+    <link rel="modulepreload" href="./scripts/packages/popup-dialog/src/popup-dialog.js">
+    <link rel="modulepreload" href="./scripts/packages/safecaller/src/safecaller.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/ydits-web.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/firebase-config.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/api/api.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/api/dmdata.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/api/p2pquake.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/api/yahoo-kmoni.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/colors/colors.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/datetime/datetime.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/debug-logs/debug-logs.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/eew/eew.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/elements/elements.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/eqinfo/eqinfo.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/geolocation/geolocation.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/intensity/intensity.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/jma/jma-data-feed.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/local-storage/local-storage.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/map/map.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/notify/notify.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/push-notify/push-notify.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/service-worker/service-worker.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/settings/settings.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/sounds/sounds.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/wolfx.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/jma-eew-rest.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/jma-eew-websocket.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/data/heart-beat.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/data/jma-eew.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/data/jma-eew-warn-area.js">
+    <link rel="modulepreload" href="./scripts/ydits-web/services/wolfx/data/jma-eew-warn-areas.js">
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>


### PR DESCRIPTION
## Changes

### Performance

- #128 
  perf: Preload core modules for app startup
  Improves page startup performance by adding modulepreload hints for the service worker, shared application scripts, YDITS Web services, render utilities, Firebase modules, and related dependencies across the main, earthquake history, and debug logs pages.
  Key changes:
    - **Add module preloads**: Preloads core local modules and external CDN dependencies so browsers can fetch the application dependency graph earlier during page load.
    - **Include service worker preload**: Adds modulepreload hints for the YDITS Web service worker alongside the web manifest references.
    - **Normalize noscript redirect**: Updates the debug logs noscript fallback to use the absolute `/noscript/` path for consistent routing.