### PR TITLE
fix(GeoLocation): 位置情報の無効時にUIが描画されない問題を修正

### DIFF
--- a/src/pages/scripts/ydits-web/services/geolocation/geolocation.js
+++ b/src/pages/scripts/ydits-web/services/geolocation/geolocation.js
@@ -284,8 +284,6 @@ export class GeoLocation extends Service {
         this.longitude = position.coords.longitude;
         this.accuracy = Math.round(position.coords.accuracy);
 
-        // this.#render();
-
         const urlOfGetCity = this.generateNominatimUrlGetCity({
             latitude: this.latitude,
             longitude: this.longitude,
@@ -410,7 +408,7 @@ export class GeoLocation extends Service {
             errorMessage
         );
 
-        // this.#render();
+        this.isGot = false;
     }
 
     /**


### PR DESCRIPTION
## Changes

### Fix

- #130 
  fix(GeoLocation): Reset acquisition state on geolocation errors
  Ensures the geolocation service marks location acquisition as unsuccessful when an error occurs, while removing obsolete commented-out render calls.
  Key changes:
    - **Error state handling**: Sets `isGot` to `false` in the geolocation error handler so downstream logic can correctly detect failed location acquisition.
    - **Dead code cleanup**: Removes stale commented-out `#render()` calls that were no longer used in either the success or error path.