### PR TITLE
docs(app-creator): `app-creator` パッケージのREADMEを変更

### DIFF
--- a/src/pages/scripts/packages/app-creator/README.md
+++ b/src/pages/scripts/packages/app-creator/README.md
@@ -34,7 +34,6 @@ class MyService extends Service {
     }
 }
 
-
 // Create a App
 class NewApp extends App {
     constructor() {
@@ -47,7 +46,7 @@ class NewApp extends App {
         });
 
         // Register new service
-        this.registerService(MyService);
+        this.services.myservice = new MyService();
 
         // Use the service (reference from Service.name)
         this.services.myservice.hello();


### PR DESCRIPTION
## Changes

### Document

- #132 
  docs(app-creator): Update README service registration example
  Updates the app-creator README example to demonstrate direct service instantiation through the app services registry instead of using the previous registerService helper.
  Key changes:
    - **Service registration example**: Replaces `this.registerService(MyService)` with `this.services.myservice = new MyService()` to show the current expected registration pattern.
    - **Formatting cleanup**: Removes an extra blank line in the code sample for tighter README formatting.