### PR TITLE
docs(firebase-app-creator): `firebase-app-creator` パッケージのREADMEを変更

### DIFF
--- a/src/pages/scripts/packages/firebase-app-creator/README.md
+++ b/src/pages/scripts/packages/firebase-app-creator/README.md
@@ -22,7 +22,6 @@ A sample code:
 // Create a Service (Use Service class @/app-creator/service.js)
 class MyService extends Service { }
 
-
 // Create a Firebase App
 class MyApp extends FirebaseApp {
     constructor() {
@@ -35,7 +34,7 @@ class MyApp extends FirebaseApp {
         });
 
         // Register new service
-        this.registerService(MyService);
+        this.services.myservice = new MyService();
 
         // Use the service (reference from Service.name)
         this.services.myservice.hello();


### PR DESCRIPTION
## Changes

### Document

- #134 
  docs(firebase-app-creator): Update service registration example
  Corrects the Firebase app creator README example so it demonstrates direct service instance assignment through the app's services registry.
  Key changes:
    - **Service registration example**: Replaces the outdated `registerService(MyService)` call with `this.services.myservice = new MyService()`.
    - **README cleanup**: Removes an extra blank line in the sample code for cleaner formatting.