### PR TITLE
perf: 404ページに `modulepreload` を指定

### DIFF
--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -63,6 +63,55 @@
     <link rel="stylesheet" href="/styles/ui.css">
     <link rel="stylesheet" href="/styles/error.css">
 
+    <!-- Preloads -->
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.1.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/version@1.0.0/version.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/render.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/app/app.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/component/component.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/element.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/elements.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/a.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/article.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/aside.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/footer.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/form.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h1.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h2.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h3.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h4.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h5.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/h6.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/head.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/header.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/nav.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ol.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/p.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/script.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/search.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/section.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/span.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/strong.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/style.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/title.js" crossorigin>
+    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/ul.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-app.js" crossorigin>
+    <link rel="modulepreload" href="https://www.gstatic.com/firebasejs/10.4.0/firebase-analytics.js" crossorigin>
+
+    <link rel="modulepreload" href="./scripts/common.js">
+
     <!-- Scripts -->
     <script src="/scripts/common.js" type="module"></script>
 
@@ -82,11 +131,11 @@
 
     <main class="error-page">
         <h2 class="error-title">404 Not Found</h2>
-        
+
         <div class="error-description">
             <p>リクエストされたページが見つかりません。</p>
         </div>
-        
+
         <a class="button error-button" href="/">
             アプリに戻る
             <span class="material-symbols-outlined">

--- a/src/pages/debug-logs/index.html
+++ b/src/pages/debug-logs/index.html
@@ -78,7 +78,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
@@ -95,7 +94,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>

--- a/src/pages/eqhistory/index.html
+++ b/src/pages/eqhistory/index.html
@@ -77,7 +77,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
@@ -94,7 +93,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -78,7 +78,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/base.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/body.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/button.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/code.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/dialog.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/div.js" crossorigin>
@@ -95,7 +94,6 @@
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/html.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/image.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/li.js" crossorigin>
-    <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/link.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/main.js" crossorigin>
     <link rel="modulepreload" href="https://cdn.yoneyo.com/scripts/render@1.0.0/elements/meta.js" crossorigin>


### PR DESCRIPTION
## Changes

### Performance

- #136 
  perf: Align module preloads across pages
  Adds the shared module preload set to the 404 page and removes duplicate preload declarations from existing app pages to keep startup resource hints consistent and avoid redundant fetch hints.
  Key changes:
    - **Add 404 preloads**: Adds modulepreload links for shared version, render, element, Firebase, and local common modules so the error page uses the same startup optimization path as the main pages.
    - **Remove duplicate hints**: Deletes repeated button and link modulepreload entries from the home, earthquake history, and debug logs pages to keep preload declarations clean and non-redundant.