### PR TITLE
feat(ogp): 各ページの description と OGP を変更

### DIFF
--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>ページが見つかりません | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="リクエストされたページが見つかりません | 『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta name="description"
+        content="リクエストされたページが見つかりません | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://webapp.ydits.net/images/icon.png">
     <meta property="og:title" content="Not Found">
-    <meta property="og:description" content="リクエストされたページが見つかりません | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta property="og:description"
+        content="リクエストされたページが見つかりません | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/debug-logs/index.html
+++ b/src/pages/debug-logs/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>デバッグログ | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta name="description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <meta property="og:title" content="デバッグログ">
-    <meta property="og:description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta property="og:description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/eqhistory/index.html
+++ b/src/pages/eqhistory/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>地震履歴 | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta name="description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <meta property="og:title" content="デバッグログ">
-    <meta property="og:description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta property="og:description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/help/index.html
+++ b/src/pages/help/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>ヘルプ | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="YDITS for Web のヘルプです。">
+    <meta name="description"
+        content="YDITS for Web のヘルプページです。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://webapp.ydits.net/images/icon.png">
     <meta property="og:title" content="ヘルプ">
-    <meta property="og:description" content="YDITS for Web のヘルプです。">
+    <meta property="og:description"
+        content="YDITS for Web のヘルプページです。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/help/sound-setting/index.html
+++ b/src/pages/help/sound-setting/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>効果音の自動再生を有効にする | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="効果音の自動再生を有効にする手順を解説します。">
+    <meta name="description"
+        content="効果音の自動再生を有効にする方法を解説します。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <meta property="og:title" content="効果音の自動再生を有効にする">
-    <meta property="og:description" content="効果音の自動再生を有効にする手順を解説します。">
+    <meta property="og:description"
+        content="効果音の自動再生を有効にする方法を解説します。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/help/support-browser/index.html
+++ b/src/pages/help/support-browser/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>サポートブラウザ | YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="YDITS for Web がサポートするブラウザを表示しています。">
+    <meta name="description"
+        content="YDITS for Web がサポートするブラウザについて。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。 ">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:title" content="サポートブラウザ">
     <meta property="og:image" content="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
-    <meta property="og:description" content="YDITS for Web がサポートするブラウザを表示しています。">
+    <meta property="og:description"
+        content="YDITS for Web がサポートするブラウザについて。 | 『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -17,7 +17,8 @@
     <!-- Meta -->
     <title>YDITS for Web</title>
     <meta name="application-name" content="YDITS for Web">
-    <meta name="description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta name="description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
@@ -33,7 +34,8 @@
     <meta property="og:site_name" content="YDITS for Web">
     <meta property="og:image" content="https://cdn.ydits.net/images/ydits_logos/ydits_icon.png">
     <meta property="og:title" content="YDITS for Web">
-    <meta property="og:description" content="『YDITS for Web』は防災情報をすぐに確認できるWebアプリケーションです。">
+    <meta property="og:description"
+        content="『YDITS for Web』は、防災情報をすぐに確認できるWebアプリケーションです。いま発表されている緊急地震速報、現在地の予想震度と主要動到達カウントダウン(警報対象時)、直近の地震情報の履歴、台風の予想進路図、雨雲レーダーを表示します。">
     <meta name="twitter:site" content="@YDITS_JP">
     <meta name="twitter:card" content="summary">
 


### PR DESCRIPTION
## Changes

### Feature

- #138 
  feat(ogp): Expand page descriptions for the features
  Updates the staged HTML metadata to provide more detailed and consistent descriptions of YDITS for Web across public, help, error, debug log, and earthquake history pages.
  Key changes:
    - **Richer Meta Descriptions**: Expands standard `description` metadata to describe the app’s disaster information features, including emergency earthquake alerts, predicted local seismic intensity, countdowns, earthquake history, typhoon forecast maps, and rain radar.
    - **Consistent Social Previews**: Aligns `og:description` content with the updated page descriptions so shared links provide clearer context across supported pages.
    - **Help Page Copy Refinements**: Adjusts help-related page descriptions to better describe each page’s purpose while preserving the broader YDITS for Web feature summary.
    - **File Formatting Cleanup**: Restores trailing newlines in updated help HTML files.