### PR TITLE
refactor(types): YditsWeb の JSDoc typedef 定義を core/types/ に切り出す

### DIFF
--- a/src/pages/scripts/ydits-web/core/types/scale-colors.js
+++ b/src/pages/scripts/ydits-web/core/types/scale-colors.js
@@ -1,0 +1,70 @@
+/*!
+ *
+ * YDITS for Web
+ *
+ * Copyright (C) よね/Yone
+ * Licensed under the Apache License 2.0.
+ *
+ * https://github.com/YDITS/YDITS-Web
+ *
+ */
+
+/**
+ * @typedef {{
+ *     "unknown": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "0": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "1": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "2": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "3": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "4": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "5-": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "5+": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "6-": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "6+": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ *     "7": {
+ *         background: string,
+ *         font: string,
+ *         border: string,
+ *     },
+ * }} scaleColors
+ */

--- a/src/pages/scripts/ydits-web/core/types/ydits-web-services.js
+++ b/src/pages/scripts/ydits-web/core/types/ydits-web-services.js
@@ -1,0 +1,44 @@
+/*!
+ *
+ * YDITS for Web
+ *
+ * Copyright (C) よね/Yone
+ * Licensed under the Apache License 2.0.
+ *
+ * https://github.com/YDITS/YDITS-Web
+ *
+ */
+
+import { Datetime } from "../../services/datetime/datetime.js";
+import { DebugLogs } from "../../services/debug-logs/debug-logs.js";
+import { ElementsManager } from "../../services/elements/elements.js";
+import { Notify } from "../../services/notify/notify.js";
+import { GeoLocation } from "../../services/geolocation/geolocation.js";
+import { Eew } from "../../services/eew/eew.js";
+import { Eqinfo } from "../../services/eqinfo/eqinfo.js";
+import { JmaDataFeed } from "../../services/jma/jma-data-feed.js";
+import { ServiceWorker } from "../../services/service-worker/service-worker.js";
+import { PushNotify } from "../../services/push-notify/push-notify.js";
+import { Sounds } from "../../services/sounds/sounds.js";
+import { Api } from "../../services/api/api.js";
+import { Settings } from "../../services/settings/settings.js";
+import { Map } from "../../services/map/map.js";
+
+/**
+ * @typedef {{
+ *     datetime: Datetime,
+ *     debugLogs: DebugLogs,
+ *     elementsManager: ElementsManager,
+ *     notify: Notify,
+ *     geoLocation: GeoLocation,
+ *     eew: Eew,
+ *     eqinfo: Eqinfo,
+ *     jmaDataFeed: JmaDataFeed,
+ *     serviceWorker: ServiceWorker,
+ *     pushNotify: PushNotify,
+ *     sounds: Sounds,
+ *     api: Api,
+ *     settings: Settings,
+ *     map: Map,
+ * }} YditsWebServices
+ */

--- a/src/pages/scripts/ydits-web/ydits-web.js
+++ b/src/pages/scripts/ydits-web/ydits-web.js
@@ -31,25 +31,6 @@ import { Settings } from "./services/settings/settings.js";
 import { Map } from "./services/map/map.js";
 
 /**
- * @typedef {{
- *     datetime: Datetime,
- *     debugLogs: DebugLogs,
- *     elementsManager: ElementsManager,
- *     notify: Notify,
- *     geoLocation: GeoLocation,
- *     eew: Eew,
- *     eqinfo: Eqinfo,
- *     jmaDataFeed: JmaDataFeed,
- *     serviceWorker: ServiceWorker,
- *     pushNotify: PushNotify,
- *     sounds: Sounds,
- *     api: Api,
- *     settings: Settings,
- *     map: Map,
- * }} YditsWebServices
- */
-
-/**
  * YDITS for Web
  */
 export class YditsWeb extends FirebaseApp {
@@ -99,7 +80,7 @@ export class YditsWeb extends FirebaseApp {
     }
 
     /**
-     * @type {YditsWebServices}
+     * @type {import("./core/types/ydits-web-services.js").YditsWebServices}
      * @override
      */
     // @ts-ignore


### PR DESCRIPTION
## 概要

`YditsWeb` に直接定義されていた JSDoc typedef を `core/types` 配下へ切り出し、型定義の責務を専用ファイルに分離します。あわせて震度スケール色設定用の typedef を追加し、今後の型参照や補完、保守をしやすくします。

## 変更内容

### Refactor

- #143
  - **YditsWebServices 型定義の切り出し**: `ydits-web.js` 内に直接記述されていた `YditsWebServices` typedef を削除し、`core/types/ydits-web-services.js` に移動しました。
  - **YditsWeb の型参照更新**: `services` プロパティの JSDoc を `import("./core/types/ydits-web-services.js").YditsWebServices` 形式に変更し、分離した型定義を参照するようにしました。
  - **サービス集合型の追加**: `Datetime`、`DebugLogs`、`ElementsManager`、`Notify`、`GeoLocation`、`Eew`、`Eqinfo`、`JmaDataFeed`、`ServiceWorker`、`PushNotify`、`Sounds`、`Api`、`Settings`、`Map` を含む `YditsWebServices` typedef を追加しました。
  - **震度スケール色型の追加**: `unknown` および震度 `0`、`1`、`2`、`3`、`4`、`5-`、`5+`、`6-`、`6+`、`7` に対応する `background`、`font`、`border` の色設定型 `scaleColors` を追加しました。

## スコープ

この PR は JSDoc typedef の配置整理と型定義追加のみを対象としています。実行時のサービス初期化処理、各サービスクラスの挙動、画面表示、API 通信、通知処理などのアプリケーションロジックは変更していません。