### PR TITLE
refactor(p2pquake): 地震情報の表示変換処理を共通ユーティリティに統一

### DIFF
--- a/src/pages/scripts/ydits-web/services/p2pquake/p2pquake.js
+++ b/src/pages/scripts/ydits-web/services/p2pquake/p2pquake.js
@@ -13,7 +13,8 @@ import { Service } from "../../../packages/app-creator/src/service.js";
 import { YditsWeb } from "../../ydits-web.js";
 import { Notify } from "../notify/notify.js";
 import { p2pquakeScaleToTextJp } from "../../core/utils/p2pquake/p2pquake-scale-to-text-jp.js";
-import { p2pquakeTsunamiTypeToTextJp } from "../../core/utils/p2pquake/p2pquake-tsunami-type-to-text-jp.js";
+import { p2pquakeEqinfoTypeToTextJpShort } from "../../core/utils/p2pquake/p2pquake-eqinfo-type-to-text-jp.js";
+import { p2pquakeTsunamiTypeToTextJpShort } from "../../core/utils/p2pquake/p2pquake-tsunami-type-to-text-jp.js";
 import { p2pquakeScaleToYditsScaleColors } from "../../core/utils/p2pquake/p2pquake-scale-to-ydits-scale-colors.js";
 
 /**
@@ -42,7 +43,7 @@ export class P2pquake extends Service {
     static REST_EQINFO_URL = new URL("https://api.p2pquake.net/v2/history?codes=551&limit=100");
 
     // DEBUG:
-    // static REST_EQINFO_URL = new URL("https://api.p2pquake.net/v2/history?codes=551&limit=100&offset=16");
+    // static REST_EQINFO_URL = new URL("https://api.p2pquake.net/v2/history?codes=551&limit=100&offset=100");
 
     /**
      * WebSocketのURL
@@ -400,7 +401,7 @@ export class P2pquake extends Service {
                         return
                     }
 
-                    list["issue"]["typeJp"] = this.#typeToText(list["issue"]["type"]);
+                    list["issue"]["typeJp"] = p2pquakeEqinfoTypeToTextJpShort(list["issue"]["type"]);
 
                     this.app.services.eqinfo.originTime = new Date(list["earthquake"]["time"]);
 
@@ -417,7 +418,7 @@ export class P2pquake extends Service {
 
                     this.app.services.eqinfo.maxScale = list['earthquake']['maxScale'];
 
-                    this.app.services.eqinfo.maxScaleText = this.#scaleToText(list['earthquake']['maxScale']);
+                    this.app.services.eqinfo.maxScaleText = p2pquakeScaleToTextJp(list['earthquake']['maxScale']);
 
                     this.app.services.eqinfo.regionName = list['earthquake']['hypocenter']['name'];
 
@@ -445,12 +446,12 @@ export class P2pquake extends Service {
 
                     this.app.services.eqinfo.tsunami = list['earthquake']['domesticTsunami'];
 
-                    this.app.services.eqinfo.tsunamiJp = this.#tsunamiTypeToText(list['earthquake']['domesticTsunami']);
+                    this.app.services.eqinfo.tsunamiJp = p2pquakeTsunamiTypeToTextJpShort(list['earthquake']['domesticTsunami']);
 
                     let bgcolor;
                     let color;
 
-                    const colors = this.#scaleToYditsScaleColors(this.app.services.eqinfo.maxScale);
+                    const colors = p2pquakeScaleToYditsScaleColors(this.app.services.eqinfo.maxScale);
                     const backgroundColor = colors.background;
                     const foregroundColor = colors.foreground;
 
@@ -722,7 +723,7 @@ export class P2pquake extends Service {
     #whenEqinfo(data) {
         this.app.services.eqinfo.type = data['issue']['type'];
 
-        this.app.services.eqinfo.typeJp = this.#typeToText(data['issue']['type']);
+        this.app.services.eqinfo.typeJp = p2pquakeEqinfoTypeToTextJpShort(data['issue']['type']);
 
         this.app.services.eqinfo.originTime = new Date(data["earthquake"]["time"]);
 
@@ -739,7 +740,7 @@ export class P2pquake extends Service {
 
         this.app.services.eqinfo.maxScale = data['earthquake']['maxScale'];
 
-        this.app.services.eqinfo.maxScaleText = this.#scaleToText(data['earthquake']['maxScale']);
+        this.app.services.eqinfo.maxScaleText = p2pquakeScaleToTextJp(data['earthquake']['maxScale']);
 
         this.app.services.eqinfo.regionName = data['earthquake']['hypocenter']['name'];
 
@@ -767,9 +768,9 @@ export class P2pquake extends Service {
 
         this.app.services.eqinfo.tsunami = data['earthquake']['domesticTsunami'];
 
-        this.app.services.eqinfo.tsunamiJp = this.#tsunamiTypeToText(data['earthquake']['domesticTsunami']);
+        this.app.services.eqinfo.tsunamiJp = p2pquakeTsunamiTypeToTextJpShort(data['earthquake']['domesticTsunami']);
 
-        const colors = this.#scaleToYditsScaleColors(this.app.services.eqinfo.maxScale);
+        const colors = p2pquakeScaleToYditsScaleColors(this.app.services.eqinfo.maxScale);
         const backgroundColor = colors.background;
         const foregroundColor = colors.foreground;
 


### PR DESCRIPTION
## 概要

P2P地震情報サービスで行っている地震情報種別、最大震度、津波情報、震度色の表示変換処理を、既存の共通ユーティリティ関数を利用する形に整理します。

## 変更内容

### Refactors

- #147
  - **地震情報種別の変換処理を共通化**: `issue.type` の日本語短縮表示に `p2pquakeEqinfoTypeToTextJpShort` を使用するよう変更しました。
  - **最大震度の表示変換を共通化**: `earthquake.maxScale` の日本語表示に `p2pquakeScaleToTextJp` を使用するよう変更しました。
  - **津波情報の表示変換を短縮表記へ統一**: `domesticTsunami` の日本語表示に `p2pquakeTsunamiTypeToTextJpShort` を使用するよう変更しました。
  - **震度色の取得処理を共通化**: 最大震度に応じた背景色・前景色の取得に `p2pquakeScaleToYditsScaleColors` を使用するよう変更しました。
  - **REST取得時とWebSocket受信時の処理を統一**: 履歴APIから取得した地震情報と、WebSocketで受信した地震情報の双方で同じ変換ユーティリティを利用するようにしました。
  - **表示変換ロジックの管理箇所を明確化**: サービス内の変換処理依存を減らし、表示文言や色定義の変更を共通ユーティリティ側で扱いやすくしました。
  - **デバッグ用API URLの確認対象を更新**: コメントアウトされているデバッグ用 `REST_EQINFO_URL` の `offset` を `16` から `100` に変更しました。

## スコープ

このPRの対象は、P2P地震情報サービスにおける表示変換処理の呼び出し元整理です。

地震情報の取得処理、通知処理、`eqinfo` サービスへ設定するデータ構造自体は変更対象外です。主に、既存の共通ユーティリティを利用することで、REST履歴取得時とWebSocket受信時の表示変換結果を揃え、今後の保守性を向上させることを目的としています。
